### PR TITLE
Native support for key rotation in verifications

### DIFF
--- a/rsa_pss_test.go
+++ b/rsa_pss_test.go
@@ -70,6 +70,18 @@ func TestRSAPSSVerify(t *testing.T) {
 		if !data.valid && err == nil {
 			t.Errorf("[%v] Invalid key passed validation", data.name)
 		}
+
+		if !data.valid {
+			continue
+		}
+		err = method.Verify(strings.Join(parts[0:2], "."), parts[2], []*rsa.PublicKey{rsaPSSKey})
+		if err != nil {
+			t.Errorf("[%v] Error while verifying key list: %v", data.name, err)
+		}
+		err = method.Verify(strings.Join(parts[0:2], "."), parts[2], []*rsa.PublicKey{})
+		if err == nil {
+			t.Errorf("[%v] Empty key list passed validation", data.name)
+		}
 	}
 }
 

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -1,6 +1,7 @@
 package jwt_test
 
 import (
+	"crypto/rsa"
 	"github.com/dgrijalva/jwt-go"
 	"io/ioutil"
 	"strings"
@@ -58,6 +59,18 @@ func TestRSAVerify(t *testing.T) {
 		}
 		if !data.valid && err == nil {
 			t.Errorf("[%v] Invalid key passed validation", data.name)
+		}
+
+		if !data.valid {
+			continue
+		}
+		err = method.Verify(strings.Join(parts[0:2], "."), parts[2], []*rsa.PublicKey{key})
+		if err != nil {
+			t.Errorf("[%v] Error while verifying key list: %v", data.name, err)
+		}
+		err = method.Verify(strings.Join(parts[0:2], "."), parts[2], []*rsa.PublicKey{})
+		if err == nil {
+			t.Errorf("[%v] Empty key list passed validation", data.name)
 		}
 	}
 }


### PR DESCRIPTION
Add native support for key rotation for ES*, HS*, RS*, and PS*
verifications.

In those SigningMethod's Verify implementations, also allow the key to
be the type of the slice of the supported key type, so that the caller
can implement the KeyFunc to return all the accepted keys together to
support key rotation.

While key rotation verification can be done on the callers' side without
this change, this change provides better performance because:

- When trying the next key, the steps before actually using the key do
  not need to be performed again.

- If a verification process failed for non-key reasons (for example,
  because it's already expired), it saves the effort to try the next
  key.